### PR TITLE
Distinguish between publication dates and meetup dates

### DIFF
--- a/content/spotkania/55.md
+++ b/content/spotkania/55.md
@@ -1,7 +1,8 @@
 ---
 title: "Meetup #55"
 date: 2024-11-27
-time: "18:00"
+meetup_date: 2024-11-27
+meetup_time: "18:00"
 place: "**IndieBI**, Piotrkowska 157A, budynek Hi Piotrkowska"
 meetup_link: "https://www.meetup.com/python-lodz/events/303808956/"
 sponsors: [indiebi, sunscrapers]

--- a/content/spotkania/56.md
+++ b/content/spotkania/56.md
@@ -1,7 +1,8 @@
 ---
 title: "Meetup #56"
 date: 2025-01-29
-time: "18:00"
+meetup_date: 2025-01-29
+meetup_time: "18:00"
 place: "**IndieBI**, Piotrkowska 157A, budynek Hi Piotrkowska"
 meetup_link: "https://www.meetup.com/python-lodz/events/305328267/"
 sponsors: [indiebi, sunscrapers]

--- a/content/spotkania/57.md
+++ b/content/spotkania/57.md
@@ -1,7 +1,8 @@
 ---
 title: "Meetup #57"
-date: 2025-03-26
-time: "18:00"
+date: 2025-03-15
+meetup_date: 2025-03-26
+meetup_time: "18:00"
 place: "**IndieBI**, Piotrkowska 157A, budynek Hi Piotrkowska"
 meetup_link: "https://www.meetup.com/python-lodz/events/305850516/"
 live_stream: ""

--- a/layouts/partials/infographic-image.html
+++ b/layouts/partials/infographic-image.html
@@ -5,7 +5,7 @@
 {{ $final := $bg }}
 
 {{ $imgWidth := $final.Width }}
-{{ $date := (printf "%sr. godz. %s" (.Page.Params.date | time.Format "Monday 02.01.2006"| strings.ToUpper) .Page.Params.time) }}
+{{ $date := (printf "%sr. godz. %s" (.Page.Params.meetup_date | time.Format "Monday 02.01.2006"| strings.ToUpper) .Page.Params.meetup_time) }}
 {{ $mainDateOptions := dict 
   "color" "#393f5f" 
   "size" 80 

--- a/layouts/shortcodes/meetup-details.html
+++ b/layouts/shortcodes/meetup-details.html
@@ -10,8 +10,8 @@
 {{ end }}
 <h2 id="prelekcje">Informacje</h2>
 <div class="header border-b pb-2">
-  <p class="text-gray-600"><strong>Data:</strong> {{ .Page.Params.date | time.Format ":date_full" }}</p>
-  <p class="text-gray-600"><strong>Godzina:</strong> {{ .Page.Params.time }}</p>
+  <p class="text-gray-600"><strong>Data:</strong> {{ .Page.Params.meetup_date | time.Format ":date_full" }}</p>
+  <p class="text-gray-600"><strong>Godzina:</strong> {{ .Page.Params.meetup_time }}</p>
   <p class="text-gray-600"><strong>Miejsce:</strong> {{ .Page.Params.place | markdownify }}</p>
   <p class="text-gray-600"><strong>Zapisy:</strong> <a href="{{ .Page.Params.meetup_link }}" target="_blank" >Meetup.com</a></p>
 </div>


### PR DESCRIPTION
The date property is used as publication date in the RSS feed so as new meetups are added the publication dates are in the future.

Adding a separate property allows defining independent publication and meetup dates.

Note: the publication date could be rendered outside of the RSS feed but currently isn't.